### PR TITLE
Added headers support to the adapter methods

### DIFF
--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -46,6 +46,7 @@ export default DS.JSONAPIAdapter.extend({
       options = {
         method: 'post',
         body: JSON.stringify(dsl),
+        headers: this.headersForRequest()
       }
     }
 
@@ -78,7 +79,8 @@ export default DS.JSONAPIAdapter.extend({
 
     return fetch(url, {
       method: "post",
-      body: JSON.stringify(es.getQuery())
+      body: JSON.stringify(es.getQuery()),
+      headers: this.headersForRequest()
     })
     .then(function(resp) {
       return resp.json();
@@ -99,7 +101,8 @@ export default DS.JSONAPIAdapter.extend({
 
     return fetch(url, {
       method: "post",
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
+      headers: this.headersForRequest()
     })
     .then(function(resp) {
       return resp.json();
@@ -118,7 +121,8 @@ export default DS.JSONAPIAdapter.extend({
 
     return fetch(url, {
       method: "post",
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
+      headers: this.headersForRequest()
     })
     .then(function(resp) {
       //console.log(resp);

--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -54,7 +54,7 @@ export default DS.JSONAPIAdapter.extend({
 
     //Ember.Logger.debug('[ES-Adapter][query]',{url, params});
 
-    return fetch(url, options).then((resp) => resp.json());
+    return fetch(url, options).then((resp) => this.handleResponse(resp.status, resp.headers, resp.json(), { url: resp.url} ));
   },
 
   buildGetQuery(query) {
@@ -82,8 +82,8 @@ export default DS.JSONAPIAdapter.extend({
       body: JSON.stringify(es.getQuery()),
       headers: this.headersForRequest()
     })
-    .then(function(resp) {
-      return resp.json();
+    .then((resp) => {
+      return this.handleResponse(resp.status, resp.headers, resp.json(), { url: resp.url} );
     });
   },
 
@@ -104,8 +104,8 @@ export default DS.JSONAPIAdapter.extend({
       body: JSON.stringify(data),
       headers: this.headersForRequest()
     })
-    .then(function(resp) {
-      return resp.json();
+    .then((resp) => {
+      return this.handleResponse(resp.status, resp.headers, resp.json(), { url: resp.url} );
     });
   },
 
@@ -124,7 +124,7 @@ export default DS.JSONAPIAdapter.extend({
       body: JSON.stringify(data),
       headers: this.headersForRequest()
     })
-    .then(function(resp) {
+    .then((resp) => {
       //console.log(resp);
       return resp.json()
         .then((_resp) => {


### PR DESCRIPTION
This change makes the add-on compatible with https://github.com/simplabs/ember-simple-auth as it uses the headers injected by the Data adapter mixin to make authenticated requests.